### PR TITLE
use cleantext for html data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugfix
 
 - Fix editor can't add a blank in firefox @iFlameing
+- Fix copied and pasting from heading block to heading block will create html for antother heading block inside the one pasted in @jackahl
 
 ## 2.1.0 (2022-07-22)
 

--- a/src/components/Edit.jsx
+++ b/src/components/Edit.jsx
@@ -25,7 +25,7 @@ class HeadingEdit extends React.Component {
     const cleanedText = event.target.value
       .replace(/<[^>]*>/g, ' ')
       .replace(/&nbsp;/g, ' ');
-    this.setState({ html: event.target.value });
+    this.setState({ html: cleanedText });
     this.props.onChangeBlock(block, { ...data, heading: cleanedText });
   };
 


### PR DESCRIPTION
Fix for an issue that happened when pasting from a heading block into itself or another heading block in edit mode. The pasted HTML would then look something like this:

```
"                  <div id=\"main\"><div class=\"ui basic segment content-area\"><main><div id=\"page-edit\"><div class=\"ui container\"><div class=\"blocks-form\"><fieldset class=\"invisible\"><div data-rbd-droppable-id=\"0ad7386e-48de-4b90-a85c-f25ea1403d73\" data-rbd-droppable-context-id=\"4\"><div data-rbd-draggable-context-id=\"4\" data-rbd-draggable-id=\"7658bcf9-8e50-4f3e-98a3-d912c3300e50\" class=\"block-editor-heading has--backgroundColor--transparent\"><div><div class=\"ui drag block inner heading\"><div role=\"presentation\" class=\"block heading  selected\"><div class=\"block heading\"><div class=\"heading-wrapper\"><h2 class=\"editable\" contenteditable=\"true\"><h2 class=\"editable\" contenteditable=\"true\">gffgfg</h2></h2></div></div></div></div></div></div></div></fieldset></div></div></div></main></div></div>&nbsp;gffgfg                                                 gffgfg                                 gffgfg                "
```