### PR TITLE
Revert "use cleantext for html data"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 ### Bugfix
 
 - Fix editor can't add a blank in firefox @iFlameing
-- Fix copied and pasting from heading block to heading block will create html for antother heading block inside the one pasted in @jackahl
 
 ## 2.1.0 (2022-07-22)
 

--- a/src/components/Edit.jsx
+++ b/src/components/Edit.jsx
@@ -25,7 +25,7 @@ class HeadingEdit extends React.Component {
     const cleanedText = event.target.value
       .replace(/<[^>]*>/g, ' ')
       .replace(/&nbsp;/g, ' ');
-    this.setState({ html: cleanedText });
+    this.setState({ html: event.target.value });
     this.props.onChangeBlock(block, { ...data, heading: cleanedText });
   };
 


### PR DESCRIPTION
Reverts kitconcept/volto-heading-block#7 reverting cause it reintroduces bug that leads to being unable to type in spaces in firefox