### PR TITLE
Set initial focus when the block gets created or edited

### DIFF
--- a/packages/volto-heading-block/news/23.bugfix
+++ b/packages/volto-heading-block/news/23.bugfix
@@ -1,0 +1,1 @@
+If the heading block on a page is selected, the page properties (text input) on the right side (sidebar) cannot get edited because the cursor keeps jumping back to the heading block. The provided change should fix this. @tomschall

--- a/packages/volto-heading-block/src/components/Edit.jsx
+++ b/packages/volto-heading-block/src/components/Edit.jsx
@@ -36,13 +36,20 @@ class HeadingEdit extends React.Component {
     super();
     this.state = {
       html: props.data.heading || '',
+      didSetInitialFocus: false,
     };
   }
 
   editable = React.createRef();
-  componentDidUpdate(prevProps) {
-    if (this.props.selected && this.editable.current) {
+  componentDidUpdate() {
+    // set initial focus when the block gets created or edited
+    if (
+      this.props.selected &&
+      !this.state.didSetInitialFocus &&
+      this.editable.current
+    ) {
       this.editable.current.focus();
+      this.setState({ didSetInitialFocus: true });
     }
   }
 
@@ -79,7 +86,7 @@ class HeadingEdit extends React.Component {
                 e.stopPropagation();
                 this.props.onSelectBlock(
                   this.props.onAddBlock(
-                    config.settings.defaultBlockType,
+                    config.settings?.defaultBlockType,
                     this.props.index + 1,
                   ),
                 );


### PR DESCRIPTION
If the heading block on a page is selected, the page properties (text input) on the right side (sidebar) cannot get edited  because the cursor keeps jumping back to the heading block. The provided change should fix this. 